### PR TITLE
removed project subtitle and other adjustments

### DIFF
--- a/src/components/projects/Projects.js
+++ b/src/components/projects/Projects.js
@@ -1,6 +1,6 @@
 import { Heading } from "../common/heading/Heading"
 import { Paragraph } from "../common/paragraph/Paragraph"
-import { ProjectCard, ProjectCards, ProjectContent, ProjectImage, ProjectWrapper, Subtitle } from "./styles"
+import { ProjectCard, ProjectCards, ProjectContent, ProjectImage, ProjectWrapper } from "./styles"
 import { data } from "./data"
 import { Subheading } from "../common/subheading/Subheading"
 import { createRef, useEffect, useRef, useState } from "react"
@@ -64,7 +64,7 @@ export const Projects = () => {
                             <a href={item.link} target="_blank" rel="noreferrer">
                                 <ProjectContent>
                                     <Subheading>{item.title}</Subheading>
-                                    <Subtitle>{item.subtitle}</Subtitle>
+                                    {/* <Subtitle>{item.subtitle}</Subtitle> */}
                                 </ProjectContent>
                                 <ProjectImage src={item.img}></ProjectImage>
                             </a>

--- a/src/components/projects/styles.js
+++ b/src/components/projects/styles.js
@@ -4,10 +4,11 @@ import { fadeIn } from "../../util/animations/fadeIn";
 
 export const ProjectWrapper = styled(ComponentWrapper)``
 
+//  unlike space-evenly space-around provides half sized spacing around the edges
 export const ProjectCards = styled.div`
     display: flex;
     width: 100%;
-    justify-content: space-between;
+    justify-content: space-around;
     flex-wrap: wrap;
 `
 export const ProjectCard = styled.div`
@@ -22,16 +23,23 @@ export const ProjectCard = styled.div`
         : css`opacity: 0;`
     }
 
+    &:hover {
+        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.15), 0 6px 20px 0 rgba(0, 0, 0, 0.1);
+    }
+
+    @media(max-width: ${globalStylingSpecs.device.medium}) {
+        width: 40%;
+        margin: 1rem auto;
+    }
+
     @media(max-width: ${globalStylingSpecs.device.small}) {
         width: 100%;
         margin: 1rem auto;
     }
 `
 export const ProjectImage = styled.img`
-    @media(max-width: ${globalStylingSpecs.device.small}) {
-        width: 100%;
-        height: 100%;
-    }
+    width: 100%;
+    height: 100%;
 `
 export const ProjectContent = styled.div`
     position: absolute;


### PR DESCRIPTION
### Developed:

1. Removed project subtitle
2. space-around justified cards in projects flex
3. Showing full size image in project card background
4. on hove box shadow on cards

### Notes:
Unlike **space-evenly**, **space-around** provides half sized spacing around the corners